### PR TITLE
Adding Markdown Layouts

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,4 +1,12 @@
-import { defineConfig } from 'astro/config';
+import { defineConfig } from "astro/config";
+
+import image from "@astrojs/image";
 
 // https://astro.build/config
-export default defineConfig({});
+export default defineConfig({
+  integrations: [
+    image({
+      serviceEntryPoint: "@astrojs/image/sharp",
+    }),
+  ],
+});

--- a/package.json
+++ b/package.json
@@ -13,9 +13,11 @@
     "astro": "astro"
   },
   "dependencies": {
-    "astro": "^2.3.2",
+    "@astrojs/image": "^0.16.7",
+    "astro": "^2.4.2",
     "astro-icon": "^0.8.0",
     "postcss": "^8.4.23",
-    "postcss-preset-env": "^8.3.2"
+    "postcss-preset-env": "^8.3.2",
+    "sharp": "^0.32.1"
   }
 }

--- a/src/components/PostHeader.astro
+++ b/src/components/PostHeader.astro
@@ -1,0 +1,34 @@
+---
+//library import
+import { Image } from "@astrojs/image/components";
+
+// utils import
+import { slugify } from "../js/utils.js";
+import { formatDate } from "../js/utils.js";
+
+const { category, title, author, date, image } = Astro.props;
+---
+
+<header>
+  <div class="container">
+    <small>
+      <a href={`/category/${slugify(category)}`} class="badge">{category}</a>
+    </small>
+    <h1 class="h2">{title}</h1>
+    <p>
+      by <a href={`/author/${slugify(author)}`}>{author}</a>
+      {formatDate(date)}
+    </p>
+  </div>
+  <Image
+    src={image.src}
+    alt={image.alt}
+    width={1200}
+    height={600}
+    format="avif"
+    fit="cover"
+    quality={80}
+    aspectRatio="5:2"
+    class="hero-image"
+  />
+</header>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,1 +1,1 @@
-/// <reference types="astro/client" />
+/// <reference types="@astrojs/image/client" />

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -1,0 +1,14 @@
+export function slugify(text) {
+  return text
+    .toString()
+    .toLowerCase()
+    .replace(/\s+/g, "-")
+    .replace(/[^\w-]+/g, "")
+    .replace(/--+/g, "-")
+    .replace(/^-+/, "")
+    .replace(/-+$/, "");
+}
+
+export function formatDate(date) {
+  return new Date(date).toLocaleDateString("en-us", { timeZone: "UTC" });
+}

--- a/src/layouts/BlogPostLayout.astro
+++ b/src/layouts/BlogPostLayout.astro
@@ -1,0 +1,19 @@
+---
+// component import
+import PostHeader from "../components/PostHeader.astro";
+import MainLayout from "./MainLayout.astro";
+
+const { frontmatter } = Astro.props;
+
+const { title, date, description, category, author, image } = frontmatter;
+---
+
+<MainLayout {title} {description}>
+  <PostHeader {title} {description} {date} {category} {author} {image} />
+  <div class="post-content">
+    <div class="content">
+      <slot />
+    </div>
+    <div class="sidebar"></div>
+  </div>
+</MainLayout>

--- a/src/pages/blog/post-1.md
+++ b/src/pages/blog/post-1.md
@@ -1,4 +1,5 @@
 ---
+layout: "../../layouts/BlogPostLayout.astro"
 title: A Post about Important Items Of Life
 date: 2022-11-20
 author: Darnell McClure

--- a/src/pages/blog/post-2.md
+++ b/src/pages/blog/post-2.md
@@ -1,4 +1,5 @@
 ---
+layout: "../../layouts/BlogPostLayout.astro"
 title: Running out of sample post ideas
 date: 2022-11-25
 author: Victoria Greenfelder

--- a/src/pages/blog/post-3.md
+++ b/src/pages/blog/post-3.md
@@ -1,4 +1,5 @@
 ---
+layout: "../../layouts/BlogPostLayout.astro"
 title: Beginning with CSS
 date: 2022-12-03
 author: Darnell McClure

--- a/src/pages/blog/post-4.md
+++ b/src/pages/blog/post-4.md
@@ -1,4 +1,5 @@
 ---
+layout: "../../layouts/BlogPostLayout.astro"
 title: Why is this CSS so weird?
 date: 2022-12-09
 author: Anna Dixon

--- a/src/pages/blog/post-5.md
+++ b/src/pages/blog/post-5.md
@@ -1,4 +1,5 @@
 ---
+layout: "../../layouts/BlogPostLayout.astro"
 title: JavaScript SchmavaScript
 date: 2022-12-05
 author: Victoria Greenfelder

--- a/src/pages/blog/post-6.md
+++ b/src/pages/blog/post-6.md
@@ -1,4 +1,5 @@
 ---
+layout: "../../layouts/BlogPostLayout.astro"
 title: Building an Astro Post Tag Component
 date: 2022-12-06
 author: Anna Dixon


### PR DESCRIPTION
* Two new components added (BlogPostLayout for structure of Markdown and PostHeader for heading & Image section of Markdown)
* New dependency added: Image by [astrojs/image](https://docs.astro.build/en/guides/integrations-guide/image/)
* Two utility functions added: slugify to replace textual jargon from its parameter `(text)` and formatDate to display accurate date inside the markdown files